### PR TITLE
Fixed bug #3826

### DIFF
--- a/lib/before.js
+++ b/lib/before.js
@@ -62,8 +62,8 @@ module.exports = function(scope, cb) {
 	if (invalidPackageJSON) {
 		return cb.invalid('Sorry, this command can only be used in the root directory of a Sails project.');
 	}
-
-	if (!scope.id) {
+	// Validate controller name
+	if (!scope.id || scope.id[scope.id.length - 1] === '/') {
 		return cb.invalid('Usage: sails generate controller <controllername> [action ...]');
 	}
 
@@ -99,8 +99,10 @@ module.exports = function(scope, cb) {
 	// Determine default values based on the
 	// available scope.
 
+	// Check if slash delimiter exists.
+	var slashIndex = scope.id.lastIndexOf('/');
 	_.defaults(scope, {
-		entity: _.str.capitalize(scope.id) + 'Controller',
+		entity: (slashIndex === -1 ? _.str.capitalize(scope.id) : _.str.splice(scope.id, slashIndex + 1, 1, scope.id.charAt(slashIndex + 1).toUpperCase())) + 'Controller',
 		resourcePlural: pluralize(scope.id),
 		ext: scope.coffee ? '.coffee' : '.js',
 		actions: [],


### PR DESCRIPTION
Hi there. Here is the fix of [issue #3826 from sails main repo](https://github.com/balderdashy/sails/issues/3826).
I also fixed case, when user provides only controller path without name like this:
`sails generate controller shop/`
Generator used to create **api/controllers/Shop/Controller.js**, now the invalid usage message will be shown.
This fork passes all [sails tests](https://github.com/balderdashy/sails/tree/master/test).